### PR TITLE
fix: 上传其他用户文件&环境变量控制链接下载

### DIFF
--- a/back/src/core/file_service.py
+++ b/back/src/core/file_service.py
@@ -160,7 +160,7 @@ class FileService:
                     raise ValueError("文件不属于当前用户")
                 if file_record.knowledge_base_id == knowledge_base_id:
                     continue  # 文件已经在知识库中，跳过
-                if file_record.knowledge_base_id is not None:
+                if file_record.knowledge_base_id and file_record.knowledge_base_id != knowledge_base_id:
                     raise ValueError("文件已属于其他知识库")
                 
                 file_record_exist = (

--- a/back/src/core/file_service.py
+++ b/back/src/core/file_service.py
@@ -156,6 +156,13 @@ class FileService:
         file_name_list = []
         try:
             for file_record in files_to_move:
+                if file_record.user_id != self.user_id:
+                    raise ValueError("文件不属于当前用户")
+                if file_record.knowledge_base_id == knowledge_base_id:
+                    continue  # 文件已经在知识库中，跳过
+                if file_record.knowledge_base_id is not None:
+                    raise ValueError("文件已属于其他知识库")
+                
                 file_record_exist = (
                     db.session.query(FileRecord)
                     .filter(

--- a/back/src/core/restful.py
+++ b/back/src/core/restful.py
@@ -205,10 +205,7 @@ class Resource(OriginResource):
                         - "write": 读写权限（租户普通成员或协作成员）
                         - "read": 只读权限（租户只读成员或内置对象）
                         - None: 无权限
-        """
-        if current_user.is_super:
-            return "admin"
-
+        """  
         # ###############
         # 其他模块的代码，在下面获取对象实例的数据: 租户ID + 创建者ID
         # 其他模块包括: 知识库/prompt/模型/数据集/工具
@@ -225,6 +222,13 @@ class Resource(OriginResource):
         elif hasattr(instance, "tenant_id") and hasattr(instance, "account_id"):
             object_tenant_id = instance.tenant_id
             object_create_id = instance.account_id
+
+        # 判断是否是内置的,内置的，所有人都有可读权限
+        if object_create_id == Account.get_administrator_id() and not current_user.is_administrator:
+            return "read"
+        
+        if current_user.is_super:
+            return "admin"
 
         # ###############
         # 其他模块的代码，在上面部分修改
@@ -254,10 +258,6 @@ class Resource(OriginResource):
 
             if role == RoleTypes.READONLY:
                 return "read"  # 同租户下至少有可读的权限
-
-        # 最后判断是否是内置的,内置的，所有人都有可读权限
-        if object_create_id == Account.get_administrator_id():
-            return "read"
 
     def check_user_del_perm(self, owner_id, raise_error=True):
         """检查当前用户是否有删除资源的权限。

--- a/back/src/parts/data/controller.py
+++ b/back/src/parts/data/controller.py
@@ -46,6 +46,7 @@ from . import fields
 from .data_service import DataService
 from .model import DataSetVersionStatus, DataSetFile, DataSetVersion, DataSet
 from .script_service import ScriptService
+from parts.knowledge_base.model import FileRecord
 
 
 class ScriptListApi(Resource):
@@ -145,6 +146,15 @@ class ScriptCreateApi(Resource):
         data = request.get_json()
         data["icon"] = data.get("icon") or "/app/upload/script.jpg"
         self.check_can_write()
+
+        file_id = data["file_id"][0]
+        if file_id is None or file_id == "":
+            raise ValueError("输入的参数格式有误")
+        file_record = db.session.query(FileRecord).filter(FileRecord.id == file_id).all()
+
+        if file_record.user_id != current_user.id:
+            raise ValueError("当前用户没有该文件的上传权限")
+
         script = ScriptService(current_user).create_script(data)
         LogService().add(
             Module.DATA_SCRIPT_MANAGEMENT,
@@ -238,8 +248,8 @@ class ScriptUploadApi(Resource):
         self.check_can_write()
 
         storage_dir = FileTools.create_script_storage(current_user.id)
-        file_path = ScriptService(current_user).upload_file_by_path(storage_dir, file)
-        return {"file_path": file_path, "message": "success", "code": 200}, 200
+        file_path, file_id = ScriptService(current_user).upload_file_by_path(storage_dir, file)
+        return {"file_path": file_path, "file_id": file_id,"message": "success", "code": 200}, 200
 
 
 class ScriptUpdateApi(Resource):
@@ -415,6 +425,7 @@ class DataSetCreateApi(Resource):
                 data_type (str): 数据类型（doc或pic）。
                 upload_type (str): 上传类型（local或url）。
                 file_paths (list, optional): 本地文件路径列表。
+                file_ids (list, optional): 文件ID列表，与file_paths一一对应。
                 file_urls (list, optional): 文件URL列表。
                 data_format (str, optional): 数据格式。
                 from_type (str, optional): 来源类型。
@@ -427,6 +438,7 @@ class DataSetCreateApi(Resource):
         """
         self.check_can_write()
         data = request.get_json()
+
         if data["name"] is None or data["name"] == "":
             raise ValueError("输入的参数格式有误")
 
@@ -439,6 +451,35 @@ class DataSetCreateApi(Resource):
         if data["upload_type"] == "local":
             if data["file_paths"] is None or data["file_paths"] == []:
                 raise ValueError("请上传文件")
+            
+            # 验证file_ids字段
+            file_ids = data.get("file_ids")
+            if file_ids is None or not isinstance(file_ids, list) or len(file_ids) == 0:
+                raise ValueError("file_ids参数格式有误，必须是非空列表")
+            
+            if len(file_ids) != len(data["file_paths"]):
+                raise ValueError("file_ids和file_paths的长度必须一致")
+            
+            try:
+                file_ids = [int(file_id) for file_id in file_ids]
+            except (ValueError, TypeError):
+                raise ValueError("file_ids中的值必须为整数")
+            
+            file_records = db.session.query(FileRecord).filter(FileRecord.id.in_(file_ids)).all()
+            
+            found_ids = {record.id for record in file_records}
+            missing_ids = set(file_ids) - found_ids
+            if missing_ids:
+                raise ValueError(f"文件ID不存在: {missing_ids}")
+            
+            for file_record in file_records:
+                if file_record.user_id != current_user.id:
+                    raise ValueError(f"当前用户没有文件ID {file_record.id} 的上传权限")
+            
+        enabled = os.getenv("INTERNET_FEATURES_ENABLED", "false").lower()
+        if enabled in ("true", "1", "yes", "on") and data["upload_type"] == "url":
+            raise ValueError("当前环境暂不支持url上传，如需使用请私有化部署")
+        
         if data["upload_type"] == "url":
             if data["file_urls"] is None or data["file_urls"] == []:
                 raise ValueError("请填写url")
@@ -578,8 +619,8 @@ class UploadDataSetFileApi(Resource):
         self.check_can_write()
 
         storage_dir = FileTools.create_temp_storage(current_user.id)
-        file_path = ScriptService(current_user).upload_file_by_path(storage_dir, file)
-        return {"file_path": file_path, "message": "success", "code": 200}, 200
+        file_path, file_id = ScriptService(current_user).upload_file_by_path(storage_dir, file)
+        return {"file_path": file_path, "file_id": file_id, "message": "success", "code": 200}, 200
 
     def check_compres_package(self, file, allowed_ext):
         """检查压缩包内的文件类型是否符合要求。

--- a/back/src/parts/data/controller.py
+++ b/back/src/parts/data/controller.py
@@ -150,8 +150,10 @@ class ScriptCreateApi(Resource):
         file_id = data["file_id"][0]
         if file_id is None or file_id == "":
             raise ValueError("输入的参数格式有误")
-        file_record = db.session.query(FileRecord).filter(FileRecord.id == file_id).all()
-
+        file_record = db.session.query(FileRecord).filter(FileRecord.id == file_id).first()
+        
+        if file_record is None:
+            raise ValueError("文件不存在")
         if file_record.user_id != current_user.id:
             raise ValueError("当前用户没有该文件的上传权限")
 
@@ -476,11 +478,10 @@ class DataSetCreateApi(Resource):
                 if file_record.user_id != current_user.id:
                     raise ValueError(f"当前用户没有文件ID {file_record.id} 的上传权限")
             
-        enabled = os.getenv("INTERNET_FEATURES_ENABLED", "false").lower()
-        if enabled in ("true", "1", "yes", "on") and data["upload_type"] == "url":
-            raise ValueError("当前环境暂不支持url上传，如需使用请私有化部署")
-        
         if data["upload_type"] == "url":
+            enabled = os.getenv("INTERNET_FEATURES_ENABLED", "false").lower()
+            if enabled not in ("true", "1", "yes", "on"):
+                raise ValueError("当前环境暂不支持url上传，如需使用请私有化部署")
             if data["file_urls"] is None or data["file_urls"] == []:
                 raise ValueError("请填写url")
 

--- a/back/src/parts/data/script_service.py
+++ b/back/src/parts/data/script_service.py
@@ -286,4 +286,4 @@ class ScriptService:
         file_record = FileRecord.init_as_other(self.user_id, filename, file_path)
         db.session.add(file_record)
         db.session.commit()
-        return file_record.file_path
+        return file_record.file_path, file_record.id

--- a/back/src/parts/knowledge_base/controller.py
+++ b/back/src/parts/knowledge_base/controller.py
@@ -192,9 +192,13 @@ class FileGetApi(Resource):
         parser.add_argument("file_id", type=str, required=True, location="json")
         args = parser.parse_args()
         file_model = FileService(current_user).get_file_by_id(args["file_id"])
-        # if file_model:
-        #     self.check_can_read_object(file_model)
 
+        if file_model.knowledge_base_id:
+            knowledge_base = KnowledgeBaseService(current_user).get_by_id(file_model.knowledge_base_id)
+        else:
+            raise ValueError("当前文件所属知识库不存在")
+        
+        self.check_can_read_object(knowledge_base)
         result = FileService(current_user).get_file_by_id(args["file_id"])
         return marshal(result, fields.file_fields)
 

--- a/back/src/parts/mcp/controller.py
+++ b/back/src/parts/mcp/controller.py
@@ -34,6 +34,7 @@ from parts.urls import api
 
 from . import fields
 from .service import McpServerService, McpToolService
+from libs.feature_gate import require_internet_feature
 
 
 class McpServerListApi(Resource):
@@ -358,6 +359,7 @@ class McpToolDetailApi(Resource):
 
 class McpServerSyncToolsApi(Resource):
     @login_required
+    @require_internet_feature("同步MCP服务器的工具")
     def post(self):
         """同步MCP服务器的工具。
 
@@ -400,6 +402,7 @@ class McpServerSyncToolsApi(Resource):
 
 class McpToolTestApi(Resource):
     @login_required
+    @require_internet_feature("MCP工具运行")
     def post(self):
         """测试MCP工具。
 

--- a/back/src/parts/models_hub/controller.py
+++ b/back/src/parts/models_hub/controller.py
@@ -35,7 +35,7 @@ from . import fields
 from .model import Lazymodel, LazymodelOnlineModels, ModelStatus
 from .model_list import online_model_list
 from .service import ModelService
-
+from libs.feature_gate import require_internet_feature
 
 class modelHubListApi(Resource):
     @login_required
@@ -159,7 +159,8 @@ class modelCreateApi(Resource):
                 raise CommonError(f"暂不支持{data['model_brand']}厂商的模型")
         model = ModelService(current_user).create_model(data)
 
-        if model.can_download:
+        enabled = os.getenv("INTERNET_FEATURES_ENABLED", "false").lower()
+        if model.can_download and enabled in ("true", "1", "yes", "on"):
 
             @copy_current_request_context
             def async_download_model(model_id, model_key, model_from, access_tokens):
@@ -254,13 +255,19 @@ class ModelOnlineListDeleteApi(Resource):
         model_keys = data.get("model_keys")
         if not model_id or not model_keys:
             return {"message": "model_id和model_keys不能为空"}, 400
-        service = ModelService(current_user)
-        result = service.delete_online_model_list(model_id, model_keys)
-        return result
+        try:
+            service = ModelService(current_user)
+            result = service.delete_online_model_list(model_id, model_keys)
+            return result
+        except CommonError as e:
+            return {"message": str(e)}, 400
+        except Exception as e:
+            return {"message": f"删除失败: {str(e)}"}, 500
 
 
 class modelRetryDownloadApi(Resource):
     @login_required
+    @require_internet_feature("重试下载模型")
     def get(self, model_id):
         """重试下载模型。
         
@@ -297,6 +304,7 @@ class modelRetryDownloadApi(Resource):
 
 class modelFinetuneRetryDownloadApi(Resource):
     @login_required
+    @require_internet_feature("重试下载微调模型")
     def get(self, model_id, finetune_model_id):
         """重试下载微调模型。
         
@@ -594,8 +602,11 @@ class ModelHubDeleteUploadedFileApi(Resource):
         self.check_can_write()
         
         service = ModelService(current_user)
-        result = service.delete_uploaded_file(filename, file_dir)
-        return result
+        try:
+            result = service.delete_uploaded_file(filename, file_dir)
+            return result
+        except Exception as e:
+            return {"message": str(e)}, 500
 
 
 class modelHubCheckModelNameApi(Resource):
@@ -752,7 +763,9 @@ class ModelCreateFinetuneApi(Resource):
         model = ModelService(current_user).create_finetune_model(
             data["base_model_id"], data, ModelStatus.START.value
         )
-        if model.can_download:
+
+        enabled = os.getenv("INTERNET_FEATURES_ENABLED", "false").lower()
+        if model.can_download and enabled in ("true", "1", "yes", "on"):
 
             @copy_current_request_context
             def async_download_model(m):

--- a/back/src/parts/prompt/manage.py
+++ b/back/src/parts/prompt/manage.py
@@ -152,7 +152,7 @@ class UpdatePrompt(Resource):
             if prompt is None:
                 return build_response(status=400, message="提示不存在")
             if prompt.is_builtin:
-                self.check_is_super()
+                self._check_object_perms(prompt)
             self.check_can_write_object(prompt)
             updated = self.prompt_service.update_prompt(prompt, args)
             if updated:

--- a/back/src/parts/prompt/manage.py
+++ b/back/src/parts/prompt/manage.py
@@ -152,7 +152,7 @@ class UpdatePrompt(Resource):
             if prompt is None:
                 return build_response(status=400, message="提示不存在")
             if prompt.is_builtin:
-                self._check_object_perms(prompt)
+                self.check_is_super()
             self.check_can_write_object(prompt)
             updated = self.prompt_service.update_prompt(prompt, args)
             if updated:

--- a/back/src/parts/tools/controller.py
+++ b/back/src/parts/tools/controller.py
@@ -260,7 +260,7 @@ class ToolFieldsDetailApi(Resource):
                 except ValueError:
                     return [fields[0]]  # 如果不能转换为整数，保留原字符串
 
-        # 处理多个元素的列表
+        # 同步MCP服务器的工具
         try:
             return [int(f) for f in fields]
         except ValueError:
@@ -270,6 +270,7 @@ class ToolFieldsDetailApi(Resource):
 class ToolApiCreateAndUpdateApi(Resource):
 
     @login_required
+    @require_internet_feature("使用外部API创建TOOL")
     def post(self):
         """HTTP部分的页面编辑(每次都是新增就很诡异)"""
         data = request.json

--- a/front/app/(appLayout)/datasets/datasetManager/CreateModal.tsx
+++ b/front/app/(appLayout)/datasets/datasetManager/CreateModal.tsx
@@ -85,8 +85,17 @@ const CreateModal = (props: any) => {
     form.validateFields().then((data) => {
       if (data.file_urls)
         data.file_urls = data.file_urls.split(',')
-      if (data.file_paths && data.file_paths.fileList && data.file_paths.fileList.length > 0)
-        data.file_paths = data.file_paths.fileList.map(item => item.response.file_path)
+      if (data.file_paths && data.file_paths.fileList && data.file_paths.fileList.length > 0) {
+        const fileList = data.file_paths.fileList
+        // 提取 file_path
+        data.file_paths = fileList.map(item => item.response?.file_path)
+        // 提取所有上传成功文件的 file_id
+        const fileIds = fileList
+          .filter(item => item.response?.file_id)
+          .map(item => item.response.file_id)
+        if (fileIds.length > 0)
+          data.file_ids = fileIds
+      }
       data.from_type = 'upload' // upload 上传， return 回流
 
       createDataset({ url: '/data/create_date_set', body: { ...data } }).then((res) => {
@@ -113,7 +122,7 @@ const CreateModal = (props: any) => {
 
   const uploadProps: UploadProps = {
     name: 'file',
-    customRequest: async ({ file, onSuccess, onError, onProgress }) => {
+    customRequest: async ({ file, onSuccess, onError, onProgress: _onProgress }) => {
       const formData = new FormData()
       formData.append('file', file)
       formData.append('file_type', form.getFieldValue('data_type'))
@@ -135,7 +144,7 @@ const CreateModal = (props: any) => {
         onSuccess?.(result)
       }
       catch (error) {
-        onError?.(error)
+        onError?.(error as Error)
       }
     },
     accept: dataType === 'doc' ? allowedDocTypes.join(',') : allowedPicTypes.join(','),

--- a/front/app/(appLayout)/datasets/scriptManager/page.tsx
+++ b/front/app/(appLayout)/datasets/scriptManager/page.tsx
@@ -144,9 +144,14 @@ const ScriptManage = () => {
     form.validateFields().then(async (values) => {
       setBtnLoading(true)
       try {
+        // 提取 file_id 并添加到请求体中（以数组形式）
+        const body: any = { ...values, icon: '' }
+        if (values.file_id)
+          body.file_id = [values.file_id]
+
         const res: any = await createPrompt({
           url: gUrl,
-          body: { ...values, icon: '' },
+          body,
         })
         if (res?.name) {
           message.success('保存成功')
@@ -195,6 +200,9 @@ const ScriptManage = () => {
       if (info.file.response?.file_path) {
         setFileList(info?.fileList)
         form.setFieldValue('script_url', info.file.response.file_path)
+        // 保存 file_id（如果响应中包含）
+        if (info.file.response?.file_id)
+          form.setFieldValue('file_id', info.file.response.file_id)
         message.success('上传成功')
       }
       else {
@@ -202,6 +210,7 @@ const ScriptManage = () => {
         const filteredFileList = info.fileList.filter((file: any) => file.status !== 'done' || file.response?.file_path)
         setFileList(filteredFileList)
         form.setFieldValue('script_url', '')
+        form.setFieldValue('file_id', '')
         message.error('上传失败，响应数据异常')
       }
     }
@@ -212,6 +221,7 @@ const ScriptManage = () => {
       const filteredFileList = info.fileList.filter((file: any) => file.status !== 'error')
       setFileList(filteredFileList)
       form.setFieldValue('script_url', '')
+      form.setFieldValue('file_id', '')
       const errorMessage = info.file.response?.message || info.file.error?.message || '上传失败，请重试'
       message.error(errorMessage)
     }
@@ -223,6 +233,7 @@ const ScriptManage = () => {
   const onRemove = () => {
     setFileList([])
     form.setFieldValue('script_url', '')
+    form.setFieldValue('file_id', '')
     return true
   }
   const normFile = (e: any) => {
@@ -354,11 +365,11 @@ const ScriptManage = () => {
         </Form.Item>
         <Input.Search allowClear onChange={onSearchChange} value={sValue} onSearch={onSearch} style={{ width: 270 }} placeholder='请输入关键字进行搜索' />
       </div>
-      {loading && !list?.length
+      {(loading && !list?.length)
         ? <div className='flex justify-center items-center' style={{ height: '400px' }}>
           <Spin size="large" tip="加载中..." />
         </div>
-        : list?.length
+        : (list?.length)
           ? <div className={style.scrollWrap} id='scrollableDiv'>
             <InfiniteScroll
               // scrollThreshold={0.3}
@@ -424,6 +435,9 @@ const ScriptManage = () => {
             <Form.Item name="script_id" hidden>
               <Input />
             </Form.Item>
+            <Form.Item name="file_id" hidden>
+              <Input />
+            </Form.Item>
             <Form.Item
               name="name"
               validateTrigger="onBlur"
@@ -449,7 +463,7 @@ const ScriptManage = () => {
                 {
                   validator: (_, value) => {
                     if (value && value.trim() === '')
-                      return Promise.reject('简介不能为空格')
+                      return Promise.reject(new Error('简介不能为空格'))
 
                     return Promise.resolve()
                   },


### PR DESCRIPTION
1. fix：用户可以通过直接调用接口的方式，将已经有归属的文件提交到其他知识库/脚本库/数据集
2. fix：使用环境变量控制，工具、MCP、模型下载中是否调用链接
3. fix：内置Prompt不能被admin或者其他用户修改